### PR TITLE
Replace /usr/share/lsf with lsf.top_dir variable

### DIFF
--- a/specs/default/chef/site-cookbooks/lsf/recipes/default.rb
+++ b/specs/default/chef/site-cookbooks/lsf/recipes/default.rb
@@ -6,6 +6,7 @@
 lsf_version = node['lsf']['version']
 lsf_kernel = node['lsf']['kernel']
 lsf_arch = node['lsf']['arch']
+lsf_top = node['lsf']['lsf_top']
 
 group node['lsf']['admin']['username'] do
   gid '6001'.to_i
@@ -62,7 +63,7 @@ var = "lsfadmin"
 file '/etc/lsf.sudoers' do
   content "
 LSF_STARTUP_USERS=\"#{var}\"
-LSF_STARTUP_PATH=\"/usr/share/lsf/#{lsf_version}/#{lsf_kernel}-#{lsf_arch}/etc\"
+LSF_STARTUP_PATH=\"#{lsf_top}/#{lsf_version}/#{lsf_kernel}-#{lsf_arch}/etc\"
 "
   mode '0600'
 end

--- a/specs/default/chef/site-cookbooks/lsf/recipes/master.rb
+++ b/specs/default/chef/site-cookbooks/lsf/recipes/master.rb
@@ -20,9 +20,10 @@ ruby_block 'check_valid_masterlist' do
   end
 end
 
-template "/usr/share/lsf/conf/lsf.conf" do
+template "#{lsf_top}/conf/lsf.conf" do
   source 'conf/lsf.conf.erb'
   variables(
+    :lsf_top => lsf_top,
     :master_list => node['lsf']['master']['ip_addresses'].map { |x| get_hostname(x) },
     :master_domain => node['domain']
   )
@@ -48,21 +49,21 @@ template "#{node['lsf']['local_etc']}/lsb.hosts" do
 end
 
 execute 'lsadmin limstartup' do 
-  command 'source /usr/share/lsf/conf/profile.lsf && lsadmin limstartup -f'
+  command "source #{lsf_top}/conf/profile.lsf && lsadmin limstartup -f"
   not_if 'pidof lim'
   user 'lsfadmin'
   group 'lsfadmin'  
 end
 
 execute 'lsadmin resstartup' do 
-  command 'source /usr/share/lsf/conf/profile.lsf && lsadmin resstartup -f'
+  command "source #{lsf_top}/conf/profile.lsf && lsadmin resstartup -f"
   not_if 'pidof res'
   user 'lsfadmin'
   group 'lsfadmin'
 end
 
 execute 'badmin hstartup' do 
-  command 'source /usr/share/lsf/conf/profile.lsf && badmin hstartup -f'
+  command "source #{lsf_top}/conf/profile.lsf && badmin hstartup -f"
   not_if 'pidof sbatchd'
   user 'lsfadmin'
   group 'lsfadmin'

--- a/specs/default/chef/site-cookbooks/lsf/recipes/slave.rb
+++ b/specs/default/chef/site-cookbooks/lsf/recipes/slave.rb
@@ -36,14 +36,14 @@ end
   
 
 execute 'lsadmin limstartup' do 
-  command 'source /usr/share/lsf/conf/profile.lsf && lsadmin limstartup -f'
+  command "source #{lsf_top}/conf/profile.lsf && lsadmin limstartup -f"
   not_if 'pidof lim'
   user 'lsfadmin'
   group 'lsfadmin'  
 end
 
 execute 'lsadmin resstartup' do 
-  command 'source /usr/share/lsf/conf/profile.lsf && lsadmin resstartup -f'
+  command "source #{lsf_top}/conf/profile.lsf && lsadmin resstartup -f"
   not_if 'pidof res'
   user 'lsfadmin'
   group 'lsfadmin'
@@ -51,7 +51,7 @@ end
 
 defer_block 'defer start of sbatchd to end of run' do
   execute 'badmin hstartup' do 
-    command 'source /usr/share/lsf/conf/profile.lsf && badmin hstartup -f'
+    command "source #{lsf_top}/conf/profile.lsf && badmin hstartup -f"
     not_if 'pidof sbatchd'
     user 'lsfadmin'
     group 'lsfadmin'

--- a/specs/default/chef/site-cookbooks/lsf/templates/conf/lsf.conf.erb
+++ b/specs/default/chef/site-cookbooks/lsf/templates/conf/lsf.conf.erb
@@ -24,10 +24,10 @@ LSB_MAILTO=!U
 LSF_AUTH=eauth
 
 # General lsfinstall variables
-LSF_MANDIR=/usr/share/lsf/10.1/man
-LSF_INCLUDEDIR=/usr/share/lsf/10.1/include
-LSF_MISC=/usr/share/lsf/10.1/misc
-XLSF_APPDIR=/usr/share/lsf/10.1/misc
+LSF_MANDIR=<%= @lsf_top %>/10.1/man
+LSF_INCLUDEDIR=<%= @lsf_top %>/10.1/include
+LSF_MISC=<%= @lsf_top %>/10.1/misc
+XLSF_APPDIR=<%= @lsf_top %>/10.1/misc
 LSF_ENVDIR=<%= node['lsf']['lsf_envdir'] %>
 
 # Internal variable to distinguish Default Install
@@ -52,15 +52,15 @@ LSF_LINK_PATH=n
 # LSF_MACHDEP and LSF_INDEP are reserved to maintain
 # backward compatibility with legacy lsfsetup.
 # They are not used in the new lsfinstall.
-LSF_INDEP=/usr/share/lsf
-LSF_MACHDEP=/usr/share/lsf/10.1
+LSF_INDEP=<%= @lsf_top %>
+LSF_MACHDEP=<%= @lsf_top %>/10.1
 
-LSF_TOP=/usr/share/lsf
+LSF_TOP=<%= @lsf_top %>
 LSF_VERSION=10.1
 LSF_ENABLE_EGO=N
-# LSF_EGO_ENVDIR=/usr/share/lsf/conf/ego/cluster1/kernel
-EGO_WORKDIR=/usr/share/lsf/work/cluster1/ego
-LSF_LIVE_CONFDIR=/usr/share/lsf/work/cluster1/live_confdir
+# LSF_EGO_ENVDIR=<%= @lsf_top %>/conf/ego/cluster1/kernel
+EGO_WORKDIR=<%= @lsf_top %>/work/cluster1/ego
+LSF_LIVE_CONFDIR=<%= @lsf_top %>/work/cluster1/live_confdir
 
 # Default tuning parameters
 


### PR DESCRIPTION
Make the LSF install directory customizable.

Tested with the default template as well as a custom template.