### PR TITLE
Always set rc_account in azurecc.profile

### DIFF
--- a/specs/default/cluster-init/files/host_provider/src/cyclecloud_provider.py
+++ b/specs/default/cluster-init/files/host_provider/src/cyclecloud_provider.py
@@ -355,15 +355,21 @@ class CycleCloudProvider:
             
             user_data = template.get("UserData")
 
-            if rc_account != "default":
-                if "lsf" not in user_data:
-                    user_data["lsf"] = {}
+            if "lsf" not in user_data:
+                user_data["lsf"] = {}
+            
+            if "custom_env" not in user_data["lsf"]:
+                user_data["lsf"]["custom_env"] = {}
                 
-                if "custom_env" not in user_data["lsf"]:
-                    user_data["lsf"]["custom_env"] = {}
-                    
-                user_data["lsf"]["custom_env"]["rc_account"] = rc_account
-                user_data["lsf"]["custom_env_names"] = " ".join(sorted(user_data["lsf"]["custom_env"].keys()))
+            if not template["attributes"]:
+                template["attributes"] = {}
+            
+            template["attributes"]["rc_account"] = ("String", rc_account)
+            if "rc_account" not in template.get("attribute_names", "").split():
+                template["attribute_names"] = template.get("attribute_names", "") + " rc_account"
+                
+            user_data["lsf"]["custom_env"]["rc_account"] = rc_account
+            user_data["lsf"]["custom_env_names"] = " ".join(sorted(user_data["lsf"]["custom_env"].keys()))
             
             nodearray = _get("nodearray")
             

--- a/specs/default/cluster-init/files/host_provider/test/cluster_init_test.py
+++ b/specs/default/cluster-init/files/host_provider/test/cluster_init_test.py
@@ -53,7 +53,9 @@ fi""" % clz.port)
         os.system("chmod +x jetpack")
 
     def setUp(self):
-        
+        if os.path.exists("/tmp/azurecc.profile"):
+            os.remove("/tmp/azurecc.profile")
+            
         self.lsf_top = tempfile.mkdtemp("lsf_top")
         os.makedirs(os.path.join(self.lsf_top, "conf"))
         with open(os.path.join(self.lsf_top, "conf", "lsf.conf"), "w") as fw:
@@ -97,6 +99,7 @@ fi""" % clz.port)
                     
     def test_execute_create_azurecc_profile(self):
         self._create_jetpack_config({"lsf": {"lsf_top": self.lsf_top,
+                                             "local_etc": "/tmp",
                                             "custom_env_names": "name1 name2",
                                             "custom_env": {"name1": "value1",
                                                            "name2": "value2"}}})
@@ -104,12 +107,15 @@ fi""" % clz.port)
         self._assert_profile_equals({"export name1": "value1", "export name2": "value2"})
         
     def test_execute_create_azurecc_profile_empty(self):
-        self._create_jetpack_config({"lsf": {"lsf_top": self.lsf_top}})
+        assert not os.path.exists("/tmp/azurecc.profile")
+        self._create_jetpack_config({"lsf": {"lsf_top": self.lsf_top,
+                                             "local_etc": "/tmp"}})
         self._call("00-create-azurecc-profile.sh")
         self._assert_profile_equals({})
         
     def test_modify_lsf_local_resources_disable(self):
         self._create_jetpack_config({"lsf": {"lsf_top": self.lsf_top,
+                                             "local_etc": "/tmp",
                                              "skip_modify_local_resources": 1,
                                              "attributes": {"custom1": "custom_value1",
                                                             "custom2": "custom_value2"},
@@ -202,7 +208,7 @@ fi""" % clz.port)
         return key_vals 
     
     def _assert_profile_equals(self, expected):
-        profile_vars = self._parse(os.path.join(self.lsf_top, "conf", "azurecc.profile"))
+        profile_vars = self._parse("/tmp/azurecc.profile")
         self.assertEquals(expected, profile_vars)
         
     def _assert_local_resources_equals(self, expected):

--- a/specs/execute/cluster-init/scripts/00-create-azurecc-profile.sh
+++ b/specs/execute/cluster-init/scripts/00-create-azurecc-profile.sh
@@ -3,7 +3,7 @@
 set -e
 
 lsf_top=$(jetpack config lsf.lsf_top)
-azurecc_profile=${lsf_top}/conf/azurecc.profile
+azurecc_profile=$(jetpack config lsf.local_etc /etc/lsf)/azurecc.profile
 
 env_names=$(jetpack config lsf.custom_env_names 0) 2> /dev/null
 

--- a/specs/execute/cluster-init/scripts/02-run-custom-script-uri.sh
+++ b/specs/execute/cluster-init/scripts/02-run-custom-script-uri.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 lsf_top=$(jetpack config lsf.lsf_top)
-azurecc_profile=${lsf_top}/conf/azurecc.profile
+azurecc_profile=$(jetpack config lsf.local_etc /etc/lsf)/azurecc.profile
 
 set +e
 source $azurecc_profile


### PR DESCRIPTION
Move azurecc.profile to local_etc so that it doesn’t end up on a shared folder.