### PR TITLE
allow anf to be used as lsf topdir

### DIFF
--- a/specs/default/chef/site-cookbooks/lsf/recipes/install.rb
+++ b/specs/default/chef/site-cookbooks/lsf/recipes/install.rb
@@ -63,7 +63,9 @@ template "#{tar_dir}/lsf#{lsf_version}_lsfinstall/lsf.install.config" do
 end
 
 execute "run_lsfinstall" do
-    command "./lsfinstall -f lsf.install.config"
+    # update install command to ignore .snapshot dir on ANF
+    # command "./lsfinstall -f lsf.install.config"
+    command "sed -i 's/grep -v lost+found/grep -v lost+found | grep -v .snapshot/g' instlib/lsfprechkfuncs.sh && ./lsfinstall -f lsf.install.config"
     cwd "#{tar_dir}/lsf#{lsf_version}_lsfinstall"
     creates "#{lsf_top}/conf/profile.lsf"
     not_if { ::File.exist?("#{lsf_top}/#{lsf_version}/#{lsf_kernel}-#{lsf_arch}/lsf_release")}

--- a/specs/default/chef/site-cookbooks/lsf/recipes/install.rb
+++ b/specs/default/chef/site-cookbooks/lsf/recipes/install.rb
@@ -63,13 +63,22 @@ template "#{tar_dir}/lsf#{lsf_version}_lsfinstall/lsf.install.config" do
 end
 
 execute "run_lsfinstall" do
+    command "./lsfinstall -f lsf.install.config"
+    cwd "#{tar_dir}/lsf#{lsf_version}_lsfinstall"
+    creates "#{lsf_top}/conf/profile.lsf"
+    not_if { ::File.exist?("#{lsf_top}/#{lsf_version}/#{lsf_kernel}-#{lsf_arch}/lsf_release")}
+    not_if { ::Dir.exist?("#{lsf_top}/#{lsf_version}")}
+    not_if { ::File.exist?("#{lsf_top}/.snapshot")}
+end
+
+execute "run_lsfinstall_on_anf" do
     # update install command to ignore .snapshot dir on ANF
-    # command "./lsfinstall -f lsf.install.config"
     command "sed -i 's/grep -v lost+found/grep -v lost+found | grep -v .snapshot/g' instlib/lsfprechkfuncs.sh && ./lsfinstall -f lsf.install.config"
     cwd "#{tar_dir}/lsf#{lsf_version}_lsfinstall"
     creates "#{lsf_top}/conf/profile.lsf"
     not_if { ::File.exist?("#{lsf_top}/#{lsf_version}/#{lsf_kernel}-#{lsf_arch}/lsf_release")}
     not_if { ::Dir.exist?("#{lsf_top}/#{lsf_version}")}
+    only_if { ::File.exist?("#{lsf_top}/.snapshot")}
 end
 
 yum_package "java-1.8.0-openjdk.x86_64" do


### PR DESCRIPTION
ANF has a .snapshot dir that can not be removed, but will stop LSF from installing since it finds a non-empty directory; this additional sed will allow the install to proceed...