### PR TITLE
Ensure stable master hostname list before generating lsf conf files

### DIFF
--- a/examples/lsf-full.txt
+++ b/examples/lsf-full.txt
@@ -1,7 +1,7 @@
 
 [cluster lsf]
     FormLayout = selectionpanel
-    Category = Infrastructure
+    Category = Schedulers
 
     [[node defaults]]
 

--- a/specs/default/chef/site-cookbooks/lsf/recipes/master.rb
+++ b/specs/default/chef/site-cookbooks/lsf/recipes/master.rb
@@ -1,4 +1,8 @@
 include_recipe "lsf::default"
+
+
+# Store updated host data to ensure searchable list has locally updated hostname
+cluster.store_discoverable()
 include_recipe "lsf::search_master"
 
 clustername = node['lsf']['clustername']


### PR DESCRIPTION
Additional validation to make sure that all  LSF conf files get the updated hostnames rather than the initial auto-generated hostnames in both single master and HA cases.