### PR TITLE
set NCPUS=threads

### DIFF
--- a/specs/default/chef/site-cookbooks/lsf/templates/conf/lsf.conf.erb
+++ b/specs/default/chef/site-cookbooks/lsf/templates/conf/lsf.conf.erb
@@ -119,3 +119,6 @@ LSF_RSH="ssh -o 'PasswordAuthentication no' -o 'StrictHostKeyChecking no'"
 LSF_STRIP_DOMAIN=.<%= @master_domain %>
 LSF_DYNAMIC_HOST_TIMEOUT=10m
 LSF_DYNAMIC_HOST_WAIT_TIME="2"
+
+# configure LSF to use threads instead of cores for host resource def
+EGO_DEFINE_NCPUS=threads


### PR DESCRIPTION
by default LSF sets NCPUS=cores so only "half" the resources of Azure VMs are available (ie. F2s_v2 has 1 core and 2 threads)